### PR TITLE
Support for Lightbearer and reorder preaches when new preaches happen

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.30'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/infernostats/GodbookConfig.java
+++ b/src/main/java/com/infernostats/GodbookConfig.java
@@ -20,6 +20,14 @@ public interface GodbookConfig extends Config
 
 	@ConfigItem(
 			position = 1,
+			keyName = "lightbearerSupport",
+			name = "Lightbearer Support",
+			description = "Additional info displayed based on ring usage"
+			)
+	default boolean lightbearerSupport() { return false; }
+
+	@ConfigItem(
+			position = 2,
 			keyName = "ticks",
 			name = "Ticks",
 			description = "How many ticks the counter remains active for"
@@ -28,4 +36,21 @@ public interface GodbookConfig extends Config
 	{
 		return 157;
 	}
+
+	@ConfigItem(
+			position = 4,
+			hidden = true,
+			keyName = "hornAnimId",
+			name = "[WIP] Extra Animation Id",
+			description = "Extra animation ID to treat as a godbook"
+	)
+	default int hornAnimId() { return 0; }
+
+	@ConfigItem(
+			position = 3,
+			keyName = "backwardsCount",
+			name = "Count Backwards",
+			description = "Display ticks until full regen, instead of ticks since preach."
+	)
+	default boolean backwardsCount() { return false; }
 }

--- a/src/main/java/com/infernostats/GodbookOverlay.java
+++ b/src/main/java/com/infernostats/GodbookOverlay.java
@@ -29,7 +29,7 @@ class GodbookOverlay extends Overlay
 	public Dimension render(Graphics2D graphics)
 	{
 		String title = "Tick:";
-		HashMap<String, Integer> players = plugin.getPlayers();
+		HashMap<String, Preach> players = plugin.getPlayers();
 
 		panelComponent.getChildren().clear();
 
@@ -44,15 +44,19 @@ class GodbookOverlay extends Overlay
 		return panelComponent.render(graphics);
 	}
 
-	private int getMaxWidth(Graphics2D graphics, HashMap<String, Integer> players, String title)
+	private int getMaxWidth(Graphics2D graphics, HashMap<String, Preach> players, String title)
 	{
 		String longestKey = Collections.max(players.keySet(), Comparator.comparingInt(String::length));
-		return graphics.getFontMetrics().stringWidth(longestKey) + graphics.getFontMetrics().stringWidth(title);
+		return graphics.getFontMetrics().stringWidth(longestKey) + graphics.getFontMetrics().stringWidth(title) + graphics.getFontMetrics().stringWidth("(157)");
 	}
 
-	private void addPlayerToOverlay(String playerName, Integer ticks)
+	private void addPlayerToOverlay(String playerName, Preach preach)
 	{
-		panelComponent.getChildren().add(LineComponent.builder().left(playerName).right(Integer.toString(ticks)).build());
+		panelComponent.getChildren().add(LineComponent.builder()
+				.leftColor(preach.preachedWithRing ? Color.YELLOW : Color.WHITE)
+				.left(playerName)
+				.right(Integer.toString(preach.tick) + (!preach.preachedWithRing && preach.ringTick != 0 ? " (" + Integer.toString(preach.ringTick) + ")" : ""))
+				.build());
 	}
 }
 

--- a/src/main/java/com/infernostats/GodbookPlugin.java
+++ b/src/main/java/com/infernostats/GodbookPlugin.java
@@ -9,13 +9,18 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.party.PartyService;
+import net.runelite.client.party.WSClient;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
-import java.util.LinkedHashMap;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @PluginDescriptor(
@@ -24,7 +29,7 @@ import java.util.LinkedHashMap;
 public class GodbookPlugin extends Plugin
 {
 	@Getter(AccessLevel.MODULE)
-	private LinkedHashMap<String, Integer> players;
+	private LinkedHashMap<String, Preach> players;
 
 	@Inject
 	private Client client;
@@ -34,6 +39,12 @@ public class GodbookPlugin extends Plugin
 
 	@Inject
 	private OverlayManager overlayManager;
+
+	@Inject
+	private PartyService partyService;
+
+	@Inject
+	private WSClient wsClient;
 
 	@Inject
 	private GodbookConfig config;
@@ -48,6 +59,7 @@ public class GodbookPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		players = new LinkedHashMap<>();
+		wsClient.registerMessage(RingChangeMessage.class);
 		overlayManager.add(overlay);
 	}
 
@@ -55,17 +67,36 @@ public class GodbookPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		wsClient.unregisterMessage(RingChangeMessage.class);
 		players.clear();
 	}
 
 	@Subscribe
 	public void onAnimationChanged(final AnimationChanged event)
 	{
+		int animId = event.getActor().getAnimation();
 		if (config.theatreOnly() && !isInTheatreOfBlood())
 			return;
 
-		if (GodbookAnimationID.isGodbookAnimation(event.getActor().getAnimation()))
-			players.put(event.getActor().getName(), 0);
+		if (GodbookAnimationID.isGodbookAnimation(animId) || isHornAnimation(animId)) {
+			boolean isLightbearerPreach = false;
+			String name = event.getActor().getName();
+
+			if (event.getActor().getName().equalsIgnoreCase(client.getLocalPlayer().getName())) {
+				if (config.lightbearerSupport()) {
+					// This is preaching, check our equipment.
+					try {
+						Item item = client.getItemContainer(InventoryID.EQUIPMENT)
+								.getItem(EquipmentInventorySlot.RING.getSlotIdx());
+						isLightbearerPreach = item.getId() == ItemID.LIGHTBEARER;
+					} catch (NullPointerException _e) {
+						isLightbearerPreach = false;
+					}
+				}
+			}
+
+			doNewPreach(name, isLightbearerPreach, 0);
+		}
 	}
 
 	@Subscribe
@@ -74,11 +105,96 @@ public class GodbookPlugin extends Plugin
 		if (players.isEmpty())
 			return;
 
-		players.entrySet()
-			.forEach(i -> i.setValue(i.getValue() + 1));
+		// Check if the localPlayer equipped a Lightbearer
+		if (config.lightbearerSupport() && players.containsKey(client.getLocalPlayer().getName())) {
+			Preach localPreach = players.get(client.getLocalPlayer().getName());
+
+			Item item;
+			try {
+				item = client.getItemContainer(InventoryID.EQUIPMENT).getItem(EquipmentInventorySlot.RING.getSlotIdx());
+			} catch (NullPointerException _e) {
+				item = null;
+			}
+
+			if (item != null && item.getId() == ItemID.LIGHTBEARER) {
+
+				if (localPreach.ringTick == 0) {
+					localPreach.ringTick = findLowestPreach();
+
+					if (partyService.isInParty()) {
+						partyService.send(new RingChangeMessage(client.getLocalPlayer().getName(), 1, localPreach.ringTick));
+					}
+				}
+			} else {
+				if (partyService.isInParty() && localPreach.ringTick != 0) {
+					partyService.send(new RingChangeMessage(client.getLocalPlayer().getName(), 0, 0));
+				}
+
+				localPreach.ringTick = 0;
+			}
+		}
 
 		players.entrySet()
-			.removeIf(i -> i.getValue() >= config.maxTicks());
+			.forEach(i -> i.setValue(i.getValue().advance(config.backwardsCount())));
+
+		players.entrySet()
+			.removeIf(this::shouldRemove);
+	}
+
+	public void doNewPreach(String name, boolean isLightbearerPreach, int offset) {
+		players.put(name,
+				new Preach(0, isLightbearerPreach, name, startTick() + offset));
+
+		// Re-order in descending order so that the lowest preach tick always appears
+		// at the bottom of the list.
+		players = players.entrySet()
+				.stream()
+				.sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
+				.collect(Collectors.toMap(
+						Map.Entry::getKey,
+						Map.Entry::getValue,
+						(oldValue, newValue) -> newValue, LinkedHashMap::new));
+	}
+
+	@Subscribe
+	public void onRingChangeMessage(RingChangeMessage e) {
+		if (!e.n.equalsIgnoreCase(client.getLocalPlayer().getName())) {
+			players.entrySet().forEach(p -> {
+				if (p.getKey().equalsIgnoreCase(e.n)) {
+					Preach remotePreach = p.getValue();
+					remotePreach.ringTick = e.r == 1 ? e.t : 0;
+					p.setValue(remotePreach);
+				}
+			});
+		}
+	}
+
+	private int findLowestPreach() {
+		// Find the lowest preach
+		final int[] lowestPreach = {Integer.MAX_VALUE};
+		players.entrySet().forEach(i -> {
+			if (lowestPreach[0] > i.getValue().tick) {
+				lowestPreach[0] = i.getValue().tick;
+			}
+		});
+
+		return lowestPreach[0];
+	}
+
+	private boolean shouldRemove(Map.Entry<String, Preach> p) {
+		if (config.backwardsCount()) {
+			return p.getValue().tick < 0;
+		} else {
+			return p.getValue().tick >= config.maxTicks();
+		}
+	}
+
+	private boolean isHornAnimation(int animId) {
+		return config.hornAnimId() != 0 && animId == config.hornAnimId();
+	}
+
+	private int startTick() {
+		return config.backwardsCount() ? 150 : 0;
 	}
 
 	private boolean isInTheatreOfBlood()

--- a/src/main/java/com/infernostats/Preach.java
+++ b/src/main/java/com/infernostats/Preach.java
@@ -1,0 +1,25 @@
+package com.infernostats;
+
+public class Preach implements Comparable<Preach> {
+    public int tick;
+    public String name;
+    public boolean preachedWithRing;
+    public int ringTick;
+
+    public Preach(int ringTick, boolean preachedWithRing, String name, int tick) {
+        this.ringTick = ringTick;
+        this.preachedWithRing = preachedWithRing;
+        this.name = name;
+        this.tick = tick;
+    }
+
+    @Override
+    public int compareTo(Preach p) {
+        return Integer.compare(p.tick, this.tick);
+    }
+
+    public Preach advance(boolean isBackwards) {
+        this.tick += isBackwards ? -1 : 1;
+        return this;
+    }
+}

--- a/src/main/java/com/infernostats/RingChangeMessage.java
+++ b/src/main/java/com/infernostats/RingChangeMessage.java
@@ -1,0 +1,15 @@
+package com.infernostats;
+
+import net.runelite.client.party.messages.PartyMessage;
+
+public class RingChangeMessage extends PartyMessage {
+    String n;
+    int r;
+    int t;
+
+    public RingChangeMessage(String n, int r, int t) {
+        this.n = n;
+        this.r = r;
+        this.t = t;
+    }
+}

--- a/src/test/java/com/infernostats/GodbookPluginTest.java
+++ b/src/test/java/com/infernostats/GodbookPluginTest.java
@@ -3,11 +3,15 @@ package com.infernostats;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
 
+import java.util.Arrays;
+
 public class GodbookPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
 		ExternalPluginManager.loadBuiltin(GodbookPlugin.class);
-		RuneLite.main(args);
+		String[] debugArgs = Arrays.copyOf(args, args.length + 1);
+		debugArgs[args.length] = "--developer-mode";
+		RuneLite.main(debugArgs);
 	}
 }


### PR DESCRIPTION
- Display the tick a player in the party has equipped their lightbearer.
- Displays players preaching with a ring with a yellow hue.
- Reorder preaches when new preaches happen so that the lowest preach is always at the bottom.